### PR TITLE
Add variants to revisions page

### DIFF
--- a/lib/beacon/live_admin/live/page_editor_live/revisions.ex
+++ b/lib/beacon/live_admin/live/page_editor_live/revisions.ex
@@ -101,7 +101,7 @@ defmodule Beacon.LiveAdmin.PageEditorLive.Revisions do
           <%= @event.snapshot.page.format %>
         </li>
         <li>
-          <h4 class="text-gray-600">Body</h4>
+          <h4 class="text-gray-600">Template</h4>
           <div class="w-full mt-2">
             <div class="py-3 bg-[#282c34] rounded-lg">
               <LiveMonacoEditor.code_editor

--- a/lib/beacon/live_admin/live/page_editor_live/revisions.ex
+++ b/lib/beacon/live_admin/live/page_editor_live/revisions.ex
@@ -9,14 +9,33 @@ defmodule Beacon.LiveAdmin.PageEditorLive.Revisions do
   def menu_link(_, _), do: :skip
 
   @impl true
-  def mount(_params, _session, socket) do
-    {:ok, assign(socket, events: [])}
+  def handle_params(%{"id" => id}, _url, socket) do
+    socket =
+      assign(socket,
+        page_id: id,
+        events: Content.list_page_events(socket.assigns.beacon_page.site, id),
+        show_variant_modal: false,
+        variant_template: nil
+      )
+
+    {:noreply, socket}
   end
 
   @impl true
-  def handle_params(%{"id" => id}, _url, socket) do
-    events = Content.list_page_events(socket.assigns.beacon_page.site, id)
-    {:noreply, assign(socket, events: events, page_id: id)}
+  def handle_event("show_modal", params, socket) do
+    %{"variant_id" => variant_id, "event_id" => event_id} = params
+    event = Enum.find(socket.assigns.events, &(&1.id == event_id))
+    variant = Enum.find(event.snapshot.page.variants, &(&1.id == variant_id))
+
+    {:noreply, assign(socket, show_variant_modal: true, variant_template: variant.template)}
+  end
+
+  def handle_event("hide_modal", _, socket) do
+    {:noreply, assign(socket, show_variant_modal: false, variant_template: nil)}
+  end
+
+  def handle_event("variant_template_editor_lost_focus", _, socket) do
+    {:noreply, socket}
   end
 
   @impl true
@@ -26,69 +45,113 @@ defmodule Beacon.LiveAdmin.PageEditorLive.Revisions do
       <Beacon.LiveAdmin.AdminComponents.page_menu socket={@socket} site={@beacon_page.site} current_action={@live_action} page_id={@page_id} />
 
       <ol class="relative border-l border-gray-200">
-        <li :for={{event, idx} <- Enum.with_index(@events)} class="mb-10 ml-6">
-          <span class="absolute flex items-center justify-center w-6 h-6 bg-blue-100 rounded-full -left-3 ring-8 ring-white">
-            <.icon :if={event.event == :published} name="hero-eye-solid" class="h-4 w-4 text-blue-800" />
-            <.icon :if={event.event == :created} name="hero-document-plus-solid" class="h-4 w-4 text-blue-800" />
-          </span>
-          <h3 class="flex items-center mb-1 text-lg font-semibold text-gray-900">
-            <%= Phoenix.Naming.humanize(event.event) %> <span class="text-sm text-gray-500 ml-2"><%= format_datetime(event.inserted_at) %></span>
-            <span :if={idx == 0} class="bg-blue-100 text-blue-800 text-sm font-medium mr-2 px-2.5 py-0.5 rounded ml-3">Latest</span>
-          </h3>
-
-          <ol :if={event.snapshot} class="space-y-3">
-            <li>
-              <h4 class="text-gray-600 text-bold">Path</h4>
-              <%= event.snapshot.page.path %>
-            </li>
-            <li>
-              <h4 class="text-gray-600">Title</h4>
-              <%= event.snapshot.page.title %>
-            </li>
-            <li>
-              <h4 class="text-gray-600">Description</h4>
-              <%= event.snapshot.page.description %>
-            </li>
-            <li>
-              <h4 class="text-gray-600">Format</h4>
-              <%= event.snapshot.page.format %>
-            </li>
-            <li>
-              <h4 class="text-gray-600">Body</h4>
-              <div class="w-full mt-2">
-                <div class="py-3 bg-[#282c34] rounded-lg">
-                  <LiveMonacoEditor.code_editor
-                    path={event.snapshot.id <> "-body"}
-                    style="min-height: 200px; width: 100%;"
-                    value={event.snapshot.page.template}
-                    opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "html", "readOnly" => "true"})}
-                  />
-                </div>
-              </div>
-            </li>
-            <li>
-              <h4 class="text-gray-600">Schema</h4>
-              <div class="w-full mt-2">
-                <div class="py-3 bg-[#282c34] rounded-lg">
-                  <LiveMonacoEditor.code_editor
-                    path={event.snapshot.id <> "-schema"}
-                    style="min-height: 200px; width: 100%;"
-                    value={Jason.encode!(event.snapshot.page.raw_schema, pretty: true)}
-                    opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "json", "readOnly" => "true"})}
-                  />
-                </div>
-              </div>
-            </li>
-            <li>
-              <h4 class="text-gray-600">Meta Tags</h4>
-              <%= render_meta_tags(event.snapshot.page.meta_tags) %>
-            </li>
-          </ol>
-        </li>
+        <%= for event <- @events do %>
+          <.revision event={event} />
+        <% end %>
       </ol>
+
+      <.modal :if={@show_variant_modal} id="variant-modal" on_cancel={JS.push("hide_modal")} show>
+        <div class="w-full mt-2">
+          <div class="py-3 bg-[#282c34] rounded-lg">
+            <LiveMonacoEditor.code_editor
+              path="variant_template"
+              style="min-height: 200px; width: 100%;"
+              value={@variant_template}
+              opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "json", "readOnly" => "true"})}
+            />
+          </div>
+        </div>
+      </.modal>
     </div>
     """
   end
+
+  ## FUNCTION COMPONENTS
+
+  attr :event, :map
+  attr :latest, :boolean, default: false
+
+  def revision(assigns) do
+    ~H"""
+    <li class="group mb-10 ml-6">
+      <span class="absolute flex items-center justify-center w-6 h-6 bg-blue-100 rounded-full -left-3 ring-8 ring-white">
+        <.icon :if={@event.event == :published} name="hero-eye-solid" class="h-4 w-4 text-blue-800" />
+        <.icon :if={@event.event == :created} name="hero-document-plus-solid" class="h-4 w-4 text-blue-800" />
+      </span>
+      <h3 class="flex items-center mb-1 text-lg font-semibold text-gray-900">
+        <%= Phoenix.Naming.humanize(@event.event) %> <span class="text-sm text-gray-500 ml-2"><%= format_datetime(@event.inserted_at) %></span>
+        <span class="hidden group-first:block bg-blue-100 text-blue-800 text-sm font-medium mr-2 px-2.5 py-0.5 rounded ml-3">Latest</span>
+      </h3>
+
+      <ol :if={@event.snapshot} class="space-y-3">
+        <li>
+          <h4 class="text-gray-600 text-bold">Path</h4>
+          <%= @event.snapshot.page.path %>
+        </li>
+        <li>
+          <h4 class="text-gray-600">Title</h4>
+          <%= @event.snapshot.page.title %>
+        </li>
+        <li>
+          <h4 class="text-gray-600">Description</h4>
+          <%= @event.snapshot.page.description %>
+        </li>
+        <li>
+          <h4 class="text-gray-600">Format</h4>
+          <%= @event.snapshot.page.format %>
+        </li>
+        <li>
+          <h4 class="text-gray-600">Body</h4>
+          <div class="w-full mt-2">
+            <div class="py-3 bg-[#282c34] rounded-lg">
+              <LiveMonacoEditor.code_editor
+                path={@event.snapshot.id <> "-body"}
+                style="min-height: 200px; width: 100%;"
+                value={@event.snapshot.page.template}
+                opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "html", "readOnly" => "true"})}
+              />
+            </div>
+          </div>
+        </li>
+        <li>
+          <h4 class="text-gray-600">Schema</h4>
+          <div class="w-full mt-2">
+            <div class="py-3 bg-[#282c34] rounded-lg">
+              <LiveMonacoEditor.code_editor
+                path={@event.snapshot.id <> "-schema"}
+                style="min-height: 200px; width: 100%;"
+                value={Jason.encode!(@event.snapshot.page.raw_schema, pretty: true)}
+                opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "json", "readOnly" => "true"})}
+              />
+            </div>
+          </div>
+        </li>
+        <li>
+          <h4 class="text-gray-600">Meta Tags</h4>
+          <%= render_meta_tags(@event.snapshot.page.meta_tags) %>
+        </li>
+        <li>
+          <h4 class="text-gray-600">Variants</h4>
+          <.table :if={@event.snapshot.page.variants != []} id="variants" rows={@event.snapshot.page.variants}>
+            <:col :let={variant} label="name">
+              <%= variant.name %>
+            </:col>
+            <:col :let={variant} label="weight">
+              <%= variant.weight %>
+            </:col>
+            <:col :let={variant} label="template">
+              <.link class="hover:underline text-blue-600" phx-click={JS.push("show_modal", value: %{event_id: @event.id, variant_id: variant.id})}>
+                Click here
+              </.link>
+            </:col>
+          </.table>
+        </li>
+      </ol>
+    </li>
+    """
+  end
+
+  ## UTILS
 
   defp format_datetime(datetime) do
     Calendar.strftime(datetime, "%B %d, %Y")


### PR DESCRIPTION
## Goal

Add a "Variants" section to each revision/snapshot on the "Revisions" page

## Implementation

* Create a `.revision` function component to simplify the template
* Replace `Enum.with_index` with a CSS-only solution for displaying "Latest" tag on the first event
* Add table to `.revision` component for listing all published variants
* Add a modal to main `render` to display variant template
* Modal opens when the variant link is clicked

## Screenshots

### Revisions page showing variants table
![Screen Shot 2023-08-09 at 3 50 20 PM](https://github.com/BeaconCMS/beacon_live_admin/assets/74077809/eddf0f38-9a40-4275-bcef-3fc4d9a9891f)

### Modal opens when link is clicked, showing variant template
![Screen Shot 2023-08-09 at 3 52 37 PM](https://github.com/BeaconCMS/beacon_live_admin/assets/74077809/5ae24612-d7c8-4da7-bbd2-63bcf35522cc)
