### PR TITLE
Fix resource links form params

### DIFF
--- a/lib/beacon/live_admin/live/layout_editor_live/resource_links.ex
+++ b/lib/beacon/live_admin/live/layout_editor_live/resource_links.ex
@@ -188,25 +188,19 @@ defmodule Beacon.LiveAdmin.LayoutEditorLive.ResourceLinks do
     case Map.fetch(params, field) do
       {:ok, map} ->
         list =
-          Enum.sort_by(map, &String.to_integer(elem(&1, 0)))
-          |> Enum.map(fn {_position, map} ->
-            Enum.reduce(map, [], fn {key, value}, acc ->
-              case value do
-                nil -> acc
-                "" -> acc
-                # only add non-empty values to the list
-                _ -> [{key, value} | acc]
-              end
-            end)
-          end)
-          |> List.flatten()
-          |> Enum.into(%{})
+          map
+          |> Enum.sort_by(&String.to_integer(elem(&1, 0)))
+          |> Enum.map(fn {_position, map} -> strip_empty_values(map) end)
 
         Map.put(params, field, list)
 
       :error ->
         params
     end
+  end
+
+  defp strip_empty_values(map) do
+    Map.reject(map, fn {_key, value} -> value in [nil, ""] end)
   end
 
   defp input_name(form_field, index, attribute) do

--- a/test/beacon/live_admin/live/layout_editor_live/edit_test.exs
+++ b/test/beacon/live_admin/live/layout_editor_live/edit_test.exs
@@ -66,11 +66,13 @@ defmodule Beacon.LiveAdmin.LayoutEditorLive.EditTest do
       })
 
     assert map == %{
-             "resource_links" => %{
-               "href" => "https://example.com",
-               "rel" => "preload",
-               "type" => "foo"
-             }
+             "resource_links" => [
+               %{
+                 "href" => "https://example.com",
+                 "rel" => "preload",
+                 "type" => "foo"
+               }
+             ]
            }
   end
 end


### PR DESCRIPTION
Resolves #103 

Resource links were broken because the logic in `coerce_resource_link_params/1` wasn't returning the correct data type.

### Expected params
```elixir
%{"resource_links" => [
  %{"rel" => "rel1", "href" => "href1"},
  %{"rel" => "rel2", "href" => "href2"}
]}
```

### Actual params
```elixir
%{"resource_links" => %{"href" => "href2", "rel" => "rel2"}}
```