### PR TITLE
Resize Content input text to fit more text

### DIFF
--- a/assets/svelte/components/PropertiesSidebar.svelte
+++ b/assets/svelte/components/PropertiesSidebar.svelte
@@ -215,7 +215,7 @@
         {#if $selectedAstElement.content?.length > 0}
           <SidebarSection
             astNodes={$selectedAstElement.content}
-            large={$selectedAstElement.tag === "eex"}
+            large={true}
             on:textChange={(e) => updateText(e)}
             on:nodesChange={changeNodes}
           >

--- a/assets/svelte/components/SidebarSection.svelte
+++ b/assets/svelte/components/SidebarSection.svelte
@@ -188,14 +188,24 @@
               </div>
             </div>
           {:else}
-            <input
-              type="text"
-              class="w-full py-1 px-2 mt-5 bg-slate-100 border-slate-100 rounded-md leading-6 text-sm"
-              {placeholder}
-              value={astNode}
-              on:keydown={handleKeydown}
-              on:change={(e) => updateNodeContents(e, idx)}
-            />
+            {#if large}
+              <textarea
+                class="w-full py-1 px-2 bg-slate-100 border-slate-100 rounded-md leading-6 text-sm"
+                {placeholder}
+                value={astNode}
+                on:keydown={handleKeydown}
+                on:change={(e) => updateNodeContents(e, idx)}
+              ></textarea>       
+            {:else}
+              <input
+                type="text"
+                class="w-full py-1 px-2 mt-5 bg-slate-100 border-slate-100 rounded-md leading-6 text-sm"
+                {placeholder}
+                value={astNode}
+                on:keydown={handleKeydown}
+                on:change={(e) => updateNodeContents(e, idx)}
+              />
+            {/if}
           {/if}
         {/each}
       {/if}


### PR DESCRIPTION
Closes #152

The field is not a texarea, which shows to rows by default but can be resize to any size by the user.
![Screenshot 2024-05-31 at 19 15 27](https://github.com/BeaconCMS/beacon_live_admin/assets/265339/e109bcd7-e2f8-498a-b624-61841d1e27b3)


Also, since now it's possible to edit in place most of the texts, this text input is not used so often.