### PR TITLE
Add code_editor field for Component body and example fields

### DIFF
--- a/lib/beacon/live_admin/content.ex
+++ b/lib/beacon/live_admin/content.ex
@@ -152,11 +152,7 @@ defmodule Beacon.LiveAdmin.Content do
     call(site, Beacon.Content, :count_components, [site, opts])
   end
 
-  def get_component(site, id) do
-    call(site, Beacon.Content, :get_component_by, [site, [id: id]])
-  end
-
-  def get_component(site, id, opts) do
+  def get_component(site, id, opts \\ []) do
     call(site, Beacon.Content, :get_component_by, [site, [id: id], opts])
   end
 
@@ -168,36 +164,36 @@ defmodule Beacon.LiveAdmin.Content do
     call(site, Beacon.Content, :update_component, [component, attrs])
   end
 
-  def change_component_attr(site, component_attr, attrs \\ %{}) do
-    call(site, Beacon.Content, :change_component_attr, [component_attr, attrs])
+  def change_component_attr(site, component_attr, attrs, component_attr_names) do
+    call(site, Beacon.Content, :change_component_attr, [component_attr, attrs, component_attr_names])
   end
 
-  def change_component_slot(site, slot, attrs \\ %{}) do
-    call(site, Beacon.Content, :change_component_slot, [slot, attrs])
+  def change_component_slot(site, slot, attrs, component_slots_names) do
+    call(site, Beacon.Content, :change_component_slot, [slot, attrs, component_slots_names])
   end
 
   def create_slot_for_component(site, component, attrs) do
     call(site, Beacon.Content, :create_slot_for_component, [component, attrs])
   end
 
-  def update_slot_for_component(site, component, slot, attrs) do
-    call(site, Beacon.Content, :update_slot_for_component, [component, slot, attrs])
+  def update_slot_for_component(site, component, slot, attrs, component_slots_names) do
+    call(site, Beacon.Content, :update_slot_for_component, [component, slot, attrs, component_slots_names])
   end
 
   def delete_slot_from_component(site, component, slot) do
     call(site, Beacon.Content, :delete_slot_from_component, [component, slot])
   end
 
-  def change_slot_attr(site, slot_attr, attrs \\ %{}) do
-    call(site, Beacon.Content, :change_slot_attr, [slot_attr, attrs])
+  def change_slot_attr(site, slot_attr, attrs, slot_attr_names) do
+    call(site, Beacon.Content, :change_slot_attr, [slot_attr, attrs, slot_attr_names])
   end
 
-  def create_slot_attr(site, attrs) do
-    call(site, Beacon.Content, :create_slot_attr, [site, attrs])
+  def create_slot_attr(site, attrs, slot_attr_names) do
+    call(site, Beacon.Content, :create_slot_attr, [site, attrs, slot_attr_names])
   end
 
-  def update_slot_attr(site, slot_attr, attrs) do
-    call(site, Beacon.Content, :update_slot_attr, [site, slot_attr, attrs])
+  def update_slot_attr(site, slot_attr, attrs, slot_attr_names) do
+    call(site, Beacon.Content, :update_slot_attr, [site, slot_attr, attrs, slot_attr_names])
   end
 
   def delete_slot_attr(site, slot_attr) do

--- a/lib/beacon/live_admin/live/component_editor_live/edit.ex
+++ b/lib/beacon/live_admin/live/component_editor_live/edit.ex
@@ -29,6 +29,24 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.Edit do
     {:noreply, socket}
   end
 
+  def handle_event("set_body", %{"value" => value}, socket) do
+    send_update(Beacon.LiveAdmin.ComponentEditorLive.FormComponent,
+      id: "components-form-edit",
+      body: value
+    )
+
+    {:noreply, socket}
+  end
+
+  def handle_event("set_example", %{"value" => value}, socket) do
+    send_update(Beacon.LiveAdmin.ComponentEditorLive.FormComponent,
+      id: "components-form-edit",
+      example: value
+    )
+
+    {:noreply, socket}
+  end
+
   @impl true
   def render(assigns) do
     ~H"""

--- a/lib/beacon/live_admin/live/component_editor_live/form_component.ex
+++ b/lib/beacon/live_admin/live/component_editor_live/form_component.ex
@@ -446,7 +446,7 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.FormComponent do
                 class="col-span-full lg:col-span-2"
                 value={Phoenix.HTML.Form.input_value(@form, :body)}
                 change="set_body"
-                opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "html"})}
+                opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "elixir"})}
               />
             </div>
           </div>

--- a/lib/beacon/live_admin/live/component_editor_live/form_component.ex
+++ b/lib/beacon/live_admin/live/component_editor_live/form_component.ex
@@ -27,6 +27,20 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.FormComponent do
     {:ok, assign_form(socket, changeset)}
   end
 
+  def update(%{body: value}, socket) do
+    params = Map.merge(socket.assigns.form.params, %{"body" => value})
+    changeset = Content.change_component(socket.assigns.site, socket.assigns.component, params)
+
+    {:ok, assign_form(socket, changeset)}
+  end
+
+  def update(%{example: value}, socket) do
+    params = Map.merge(socket.assigns.form.params, %{"example" => value})
+    changeset = Content.change_component(socket.assigns.site, socket.assigns.component, params)
+
+    {:ok, assign_form(socket, changeset)}
+  end
+
   defp save_component(socket, :new, component_params) do
     case Content.create_component(socket.assigns.site, component_params) do
       {:ok, component} ->
@@ -128,6 +142,7 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.FormComponent do
       Content.change_component(site, component, %{
         "name" => get_field(component_form.source, :name),
         "category" => get_field(component_form.source, :category),
+        "body" => get_field(component_form.source, :body),
         "example" => get_field(component_form.source, :example),
         "template" => get_field(component_form.source, :template),
         "attrs" => updated_attr_params
@@ -255,6 +270,7 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.FormComponent do
     Content.change_component(site, component, %{
       "name" => get_field(form.source, :name),
       "category" => get_field(form.source, :category),
+      "body" => get_field(form.source, :body),
       "example" => get_field(form.source, :example),
       "template" => get_field(form.source, :template),
       "attrs" => updated_attr_params
@@ -278,6 +294,7 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.FormComponent do
     Content.change_component(site, component, %{
       "name" => get_field(form.source, :name),
       "category" => get_field(form.source, :category),
+      "body" => get_field(form.source, :body),
       "example" => get_field(form.source, :example),
       "template" => get_field(form.source, :template),
       "attrs" => updated_attr_params
@@ -371,8 +388,9 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.FormComponent do
             <legend class="text-sm font-bold tracking-widest text-[#445668] uppercase">Component settings</legend>
             <.input field={f[:name]} type="text" label="Name" />
             <.input field={f[:category]} type="select" options={categories_to_options(@site)} label="Category" />
-            <.input field={f[:example]} type="text" label="Example" />
+            <input type="hidden" name="component[body]" id="component-form_body" value={Phoenix.HTML.Form.input_value(f, :body)} />
             <input type="hidden" name="component[template]" id="component-form_template" value={Phoenix.HTML.Form.input_value(f, :template)} />
+            <input type="hidden" name="component[example]" id="component-form_example" value={Phoenix.HTML.Form.input_value(f, :example)} />
 
             <.inputs_for :let={f_attr} field={f[:attrs]}>
               <.input type="hidden" field={f_attr[:id]} />
@@ -418,16 +436,47 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.FormComponent do
 
           <.button class="mt-4" phx-click={JS.push("show_attr_modal", target: @myself)}>Add new Attribute</.button>
         </div>
-        <div class="col-span-full lg:col-span-2">
-          <%= template_error(@form[:template]) %>
-          <div class="py-6 w-full rounded-[1.25rem] bg-[#0D1829] [&_.monaco-editor-background]:!bg-[#0D1829] [&_.margin]:!bg-[#0D1829]">
-            <LiveMonacoEditor.code_editor
-              path="template"
-              class="col-span-full lg:col-span-2"
-              value={Phoenix.HTML.Form.input_value(@form, :template)}
-              change="set_template"
-              opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "html"})}
-            />
+        <div class="col-span-full lg:col-span-2 space-y-6">
+          <div>
+            <.label for={@form[:body].id}>Body</.label>
+            <%= template_error(@form[:body]) %>
+            <div class="py-6 w-full rounded-[1.25rem] bg-[#0D1829] [&_.monaco-editor-background]:!bg-[#0D1829] [&_.margin]:!bg-[#0D1829]">
+              <LiveMonacoEditor.code_editor
+                path="body"
+                class="col-span-full lg:col-span-2"
+                value={Phoenix.HTML.Form.input_value(@form, :body)}
+                change="set_body"
+                opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "html"})}
+              />
+            </div>
+          </div>
+
+          <div>
+            <.label for={@form[:template].id}>Template</.label>
+            <%= template_error(@form[:template]) %>
+            <div class="py-6 w-full rounded-[1.25rem] bg-[#0D1829] [&_.monaco-editor-background]:!bg-[#0D1829] [&_.margin]:!bg-[#0D1829]">
+              <LiveMonacoEditor.code_editor
+                path="template"
+                class="col-span-full lg:col-span-2"
+                value={Phoenix.HTML.Form.input_value(@form, :template)}
+                change="set_template"
+                opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "html"})}
+              />
+            </div>
+          </div>
+
+          <div>
+            <.label for={@form[:example].id}>Example</.label>
+            <%= template_error(@form[:example]) %>
+            <div class="py-6 w-full rounded-[1.25rem] bg-[#0D1829] [&_.monaco-editor-background]:!bg-[#0D1829] [&_.margin]:!bg-[#0D1829]">
+              <LiveMonacoEditor.code_editor
+                path="example"
+                class="col-span-full lg:col-span-2"
+                value={Phoenix.HTML.Form.input_value(@form, :example)}
+                change="set_example"
+                opts={Map.merge(LiveMonacoEditor.default_opts(), %{"language" => "html"})}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/lib/beacon/live_admin/live/component_editor_live/form_component.ex
+++ b/lib/beacon/live_admin/live/component_editor_live/form_component.ex
@@ -208,7 +208,7 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.FormComponent do
     component_attr_params = format_struct_name_input(component_attr_params)
     component_attr_params = format_options_input(component_attr_params)
 
-    component_attr_names = get_field(form.source, :attrs ) |> Enum.reject(& &1.id == attr_form.data.id) |> Enum.map(& &1.name)
+    component_attr_names = get_field(form.source, :attrs) |> Enum.reject(&(&1.id == attr_form.data.id)) |> Enum.map(& &1.name)
 
     changeset =
       site
@@ -240,7 +240,7 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.FormComponent do
   end
 
   defp build_attr_form(site, attr_or_changeset, params, component_form, action \\ nil) do
-    component_attr_names = get_field(component_form.source, :attrs ) |> Enum.reject(& &1.id == attr_or_changeset.id) |> Enum.map(& &1.name)
+    component_attr_names = get_field(component_form.source, :attrs) |> Enum.reject(&(&1.id == attr_or_changeset.id)) |> Enum.map(& &1.name)
 
     changeset =
       site

--- a/lib/beacon/live_admin/live/component_editor_live/new.ex
+++ b/lib/beacon/live_admin/live/component_editor_live/new.ex
@@ -27,6 +27,24 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.New do
     {:noreply, socket}
   end
 
+  def handle_event("set_body", %{"value" => value}, socket) do
+    send_update(Beacon.LiveAdmin.ComponentEditorLive.FormComponent,
+      id: "components-editor-form-new",
+      body: value
+    )
+
+    {:noreply, socket}
+  end
+
+  def handle_event("set_example", %{"value" => value}, socket) do
+    send_update(Beacon.LiveAdmin.ComponentEditorLive.FormComponent,
+      id: "components-editor-form-new",
+      example: value
+    )
+
+    {:noreply, socket}
+  end
+
   @impl true
   def render(assigns) do
     ~H"""

--- a/lib/beacon/live_admin/live/component_editor_live/slots.ex
+++ b/lib/beacon/live_admin/live/component_editor_live/slots.ex
@@ -95,7 +95,8 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.Slots do
     %{component: component, beacon_page: %{site: site}} = socket.assigns
     selected = socket.assigns.selected || %{id: nil}
 
-    attrs = %{name: "New Slot"}
+    random_string = Ecto.UUID.generate() |> String.slice(0..5)
+    attrs = %{name: "new_slot_#{random_string}"}
     {:ok, updated_component} = Content.create_slot_for_component(site, component, attrs)
 
     socket =

--- a/lib/beacon/live_admin/live/component_editor_live/slots.ex
+++ b/lib/beacon/live_admin/live/component_editor_live/slots.ex
@@ -52,13 +52,14 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.Slots do
   end
 
   def handle_event("validate", %{"component_slot" => params}, socket) do
-    %{selected: selected, beacon_page: %{site: site}} = socket.assigns
+    %{selected: selected, beacon_page: %{site: site}, component: component} = socket.assigns
 
+    component_slots_names = component.slots |> Enum.reject(& &1.id == selected.id) |> Enum.map(& &1.name)
     params = format_options_input(params)
 
     changeset =
       site
-      |> Content.change_component_slot(selected, params)
+      |> Content.change_component_slot(selected, params, component_slots_names)
       |> Map.put(:action, :validate)
 
     socket =
@@ -72,20 +73,18 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.Slots do
   def handle_event("save_changes", %{"component_slot" => params}, socket) do
     %{component: component, selected: selected, beacon_page: %{site: site}} = socket.assigns
 
+    component_slots_names = component.slots |> Enum.reject(& &1.id == selected.id) |> Enum.map(& &1.name)
     params = format_options_input(params)
 
     socket =
-      case Content.update_slot_for_component(site, component, selected, params) do
+      case Content.update_slot_for_component(site, component, selected, params, component_slots_names) do
         {:ok, updated_component} ->
-          socket
-          |> assign(component: updated_component)
-          |> assign_selected(selected.id)
-          |> assign_form()
-          |> assign(unsaved_changes: false)
+          path = beacon_live_admin_path(socket, site, "/components/#{updated_component.id}/slots/#{selected.id}")
+          push_navigate(socket, to: path)
 
         {:error, changeset} ->
           changeset = Map.put(changeset, :action, :update)
-          assign_form(changeset)
+          assign_form(socket, changeset)
       end
 
     {:noreply, socket}
@@ -99,10 +98,8 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.Slots do
     attrs = %{name: "new_slot_#{random_string}"}
     {:ok, updated_component} = Content.create_slot_for_component(site, component, attrs)
 
-    socket =
-      socket
-      |> assign(component: updated_component)
-      |> assign_selected(selected.id)
+    path = beacon_live_admin_path(socket, site, "/components/#{updated_component.id}/slots/#{selected.id}")
+    socket = push_navigate(socket, to: path)
 
     {:noreply, assign(socket, component: updated_component)}
   end
@@ -267,7 +264,7 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.Slots do
 
         %{selected: selected, beacon_page: %{site: site}} ->
           site
-          |> Content.change_component_slot(selected)
+          |> Content.change_component_slot(selected, %{}, [])
           |> to_form()
       end
 

--- a/lib/beacon/live_admin/live/component_editor_live/slots.ex
+++ b/lib/beacon/live_admin/live/component_editor_live/slots.ex
@@ -54,7 +54,7 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.Slots do
   def handle_event("validate", %{"component_slot" => params}, socket) do
     %{selected: selected, beacon_page: %{site: site}, component: component} = socket.assigns
 
-    component_slots_names = component.slots |> Enum.reject(& &1.id == selected.id) |> Enum.map(& &1.name)
+    component_slots_names = component.slots |> Enum.reject(&(&1.id == selected.id)) |> Enum.map(& &1.name)
     params = format_options_input(params)
 
     changeset =
@@ -73,7 +73,7 @@ defmodule Beacon.LiveAdmin.ComponentEditorLive.Slots do
   def handle_event("save_changes", %{"component_slot" => params}, socket) do
     %{component: component, selected: selected, beacon_page: %{site: site}} = socket.assigns
 
-    component_slots_names = component.slots |> Enum.reject(& &1.id == selected.id) |> Enum.map(& &1.name)
+    component_slots_names = component.slots |> Enum.reject(&(&1.id == selected.id)) |> Enum.map(& &1.name)
     params = format_options_input(params)
 
     socket =


### PR DESCRIPTION
- Remove Example input text field from Component form;
- Add a CodeEditor field to body and template in the Component form;
- When clicking "New Slot", creates a Slot for the component with unique name;
- Add changeset validations - Unique name for ComponentAttr, ComponentSlot and ComponentSlotAttr

before:
<img width="1716" alt="Screenshot 2024-07-12 at 6 21 13 PM" src="https://github.com/user-attachments/assets/468032a6-6592-45c2-82ef-455ff8dbcb0f">

after:
<img width="1706" alt="Screenshot 2024-07-12 at 6 39 39 PM" src="https://github.com/user-attachments/assets/a90da6f7-9da4-4d8b-ae41-def9461a8248">

