### PR TITLE
Add new component category in ComponentsSidebar

### DIFF
--- a/assets/svelte/components/ComponentsSidebar.svelte
+++ b/assets/svelte/components/ComponentsSidebar.svelte
@@ -31,6 +31,7 @@
     data: "Data",
     element: "Elements",
     media: "Media",
+    section: "Section",
   }
 
   let showExamples = false


### PR DESCRIPTION
- Add the Section Component Category in ComponentsSidebar (it was necessary, otherwise the word 'undefined' appered instead of the word 'Section')
<img width="1618" alt="Screenshot 2024-07-19 at 8 30 04 PM" src="https://github.com/user-attachments/assets/40955f2d-cc23-4848-907c-95201a268a0f">
