### PR TITLE
Remove defunct reference to agent assigns

### DIFF
--- a/lib/beacon/live_admin/live/media_library_live/index.ex
+++ b/lib/beacon/live_admin/live/media_library_live/index.ex
@@ -157,7 +157,6 @@ defmodule Beacon.LiveAdmin.MediaLibraryLive.Index do
           live_action={@live_action}
           asset={@asset}
           navigate={beacon_live_admin_path(@socket, @beacon_page.site, "/media_library")}
-          agent={@agent}
         />
       </.modal>
 
@@ -169,7 +168,6 @@ defmodule Beacon.LiveAdmin.MediaLibraryLive.Index do
           live_action={@live_action}
           asset={@asset}
           navigate={beacon_live_admin_path(@socket, @beacon_page.site, "/media_library")}
-          agent={@agent}
         />
       </.modal>
       <.table_pagination socket={@socket} page={@beacon_page} />


### PR DESCRIPTION
It appears that agent authorization was removed in #189, but several components still have references to an `@agent` assigns that no longer exists. This PR removes those references and fixes the reference to the missing key/value in the assigns. This seems to make the upload media components work again.