### PR TITLE
Issue 205: Reset drag states when dropping, even on invalid targets

### DIFF
--- a/assets/svelte/components/ComponentsSidebar.svelte
+++ b/assets/svelte/components/ComponentsSidebar.svelte
@@ -2,7 +2,7 @@
   import { fade } from "svelte/transition"
   import { translate } from "$lib/utils/animations"
   import { currentComponentCategory } from "$lib/stores/currentComponentCategory"
-  import { draggedObject } from "$lib/stores/dragAndDrop"
+  import { draggedObject, resetDrag } from "$lib/stores/dragAndDrop"
   import type { ComponentCategory, ComponentDefinition, MenuCategory } from "$lib/types"
   export let components: ComponentDefinition[]
 
@@ -70,7 +70,7 @@
   }
 
   function dragEnd() {
-    $draggedObject = null
+    resetDrag();
   }
 </script>
 

--- a/assets/svelte/components/ComponentsSidebar.svelte
+++ b/assets/svelte/components/ComponentsSidebar.svelte
@@ -70,7 +70,7 @@
   }
 
   function dragEnd() {
-    resetDrag();
+    resetDrag()
   }
 </script>
 

--- a/assets/svelte/components/PagePreview.svelte
+++ b/assets/svelte/components/PagePreview.svelte
@@ -4,7 +4,7 @@
   import { selectedAstElementId } from "$lib/stores/page"
   import { currentComponentCategory } from "$lib/stores/currentComponentCategory"
   import { page, slotTargetElement } from "$lib/stores/page"
-  import { draggedObject } from "$lib/stores/dragAndDrop"
+  import { draggedObject, resetDrag } from "$lib/stores/dragAndDrop"
   import { live } from "$lib/stores/live"
   import { elementCanBeDroppedInTarget } from "$lib/utils/drag-helpers"
 
@@ -16,10 +16,14 @@
     if (!$draggedObject) return
     let draggedObj = $draggedObject
     if (elementCanBeDroppedInTarget(draggedObj)) {
-      if (!(target instanceof HTMLElement)) return
-      if (target.id === "fake-browser-content") return
-      if (!$slotTargetElement) return
-      if ($slotTargetElement.attrs.selfClose) return
+      if (!(target instanceof HTMLElement) ||
+          target.id === "fake-browser-content" ||
+          !$slotTargetElement ||
+          $slotTargetElement.attrs.selfClose) {
+        resetDragDrop()
+        return
+      }
+
       addBasicComponentToTarget($slotTargetElement)
     } else {
       $live.pushEvent(
@@ -31,8 +35,7 @@
         },
       )
     }
-    $draggedObject = null
-    isDraggingOver = false
+    resetDragDrop()
   }
 
   async function addBasicComponentToTarget(astElement: AstElement) {
@@ -53,6 +56,11 @@
 
   function dragOver() {
     isDraggingOver = true
+  }
+
+  function resetDragDrop() {
+    resetDrag();
+    isDraggingOver = false
   }
 </script>
 

--- a/assets/svelte/components/PagePreview.svelte
+++ b/assets/svelte/components/PagePreview.svelte
@@ -16,10 +16,12 @@
     if (!$draggedObject) return
     let draggedObj = $draggedObject
     if (elementCanBeDroppedInTarget(draggedObj)) {
-      if (!(target instanceof HTMLElement) ||
-          target.id === "fake-browser-content" ||
-          !$slotTargetElement ||
-          $slotTargetElement.attrs.selfClose) {
+      if (
+        !(target instanceof HTMLElement) ||
+        target.id === "fake-browser-content" ||
+        !$slotTargetElement ||
+        $slotTargetElement.attrs.selfClose
+      ) {
         resetDragDrop()
         return
       }
@@ -59,7 +61,7 @@
   }
 
   function resetDragDrop() {
-    resetDrag();
+    resetDrag()
     isDraggingOver = false
   }
 </script>

--- a/assets/svelte/stores/dragAndDrop.ts
+++ b/assets/svelte/stores/dragAndDrop.ts
@@ -24,3 +24,7 @@ interface DragInfo {
   siblingLocationInfos: LocationInfo[]
 }
 export const dragElementInfo: Writable<DragInfo | null> = writable(null)
+
+export const resetDrag: () => void = () => {
+  draggedObject.update(() => null)
+}


### PR DESCRIPTION
Closes #205 : Dropping a dragged object into invalid target breaks the component sidebar

## Description
After dropping any element on an invalid target, the component sidebar was staying disabled. 

## In this PR
* Making sure that the drag state is being reset, even after dropping on an invalid target
* Add a generic `resetDrag` function so we can trigger that from different places, and for future improvements keep the logic of resetting the state in one place

Before, it was just returning from the `drop` even handler when the target was invalid, but the `draggedObject` was still set. Therefore the app still thinks it's in drag mode, and disabling the component sidebar.

## Testing Notes
1. Open any of the page editors
2. Use the sidebar to drag a component (any will work)
3. Drop the component on the most outer wrapper (the fake browser content)
4. Verify: The drag mode is reset and the component sidebar can be used again

## Before / After
Before|After
---|---
Stays in drag mode, component sidebar disabled|Resets drag mode, interaction enabled
![358613618-9fe7b037-193e-4ea4-8871-5cd6ef699055](https://github.com/user-attachments/assets/854b4e20-9c45-440d-9df1-c6cf0bef86d1)|![205-reset-drag-on-invalid-after](https://github.com/user-attachments/assets/8f0dbaa8-2f49-45ba-bbe4-a8dd90bd7f76)



