### PR TITLE
Issue 203: Disable dragLeave trigger on drag placeholder

### DIFF
--- a/assets/svelte/components/PageAstNode.svelte
+++ b/assets/svelte/components/PageAstNode.svelte
@@ -227,6 +227,9 @@
 <style>
   .dragged-element-placeholder {
     outline: 2px dashed red;
+
+    /* Disable pointer events to block out any dragOver event triggers on the placeholder while dragging */
+    pointer-events: none;
   }
 
   :global(.embedded-iframe) {


### PR DESCRIPTION
Closes #203: Improve target placement

## Description
When dragging in a new element, the placeholder starts flashing. That's because having the cursor enter the placeholder triggers a `dragLeave` on the parent and therefor doesn't capture the action as still wanting to drop something in that parent.

## In this PR
* Disable `dragLeave` trigger on drag placeholder (or basically any pointer/drag events, because the placeholder is just a visual placeholder and should be handled as a non-existing element. The events are still being triggered on the parent as expected. 

<!-- Removing this notes, because I think we already cover for this by doing a check on dragLeave for $slotTargetElement === node
### Notes
Leaving this for future reference: This issue might also be something we have to investigate when dragging over a child element that doesn't allow dropping, while the parent still should. Does that cause issues or decrease the user experience when you still want to drop something on that parent? 

### TODO
- [ ] Considering a different solution to check whether we can drag/drop something on the child that triggers the dragLeave. In that case we will also solve the other issue just mentioned for children that don't allow elements to be dropped on.
-->

## Testing Notes
1. Edit a Page
2. Drag a new element into the visual editor
3. Make sure to drag over it's own placeholder
4. Verify: dragging over the placeholder doesn't remove it or cause any disturbances in how the placeholder is being displayed

## Before / After
Before|After
---|---
![204-dragleave-triggered-on-drag-placeholder-before](https://github.com/user-attachments/assets/42eabcd4-f654-456f-a393-40a93f5dee9a)|![204-dragleave-triggered-on-drag-placeholder-after](https://github.com/user-attachments/assets/94936611-2e51-4e78-86b5-491da893da97)
