### PR TITLE
[Bufgix] After sorting elements with drag and drop, the same items should stay selected

### DIFF
--- a/assets/svelte/components/SelectedElementFloatingMenu/DragMenuOption.svelte
+++ b/assets/svelte/components/SelectedElementFloatingMenu/DragMenuOption.svelte
@@ -1,10 +1,10 @@
 <script lang="ts" context="module">
   import { get, writable, type Writable } from "svelte/store"
-  import { page, selectedDomElement, selectedElementMenu, parentOfSelectedAstElement } from "$lib/stores/page"
+  import { page, selectedDomElement, selectedAstElementId, selectedElementMenu, parentOfSelectedAstElement } from "$lib/stores/page"
   import { dragElementInfo, type LocationInfo } from "$lib/stores/dragAndDrop"
   import { getDragDirection, type Coords, type DragDirection } from "$lib/utils/drag-helpers"
   import { live } from "$lib/stores/live"
-
+ 
   let currentHandleCoords: Coords
   let relativeWrapperRect: DOMRect
   let dragHandleStyle: Writable<string> = writable("")
@@ -96,7 +96,12 @@
       let parent = $parentOfSelectedAstElement
       const selectedAstElement = parent.content.splice($dragElementInfo.selectedIndex, 1)[0]
       parent.content.splice(newIndex, 0, selectedAstElement)
+      // Update the selectedAstElementId so the same item remains selected
       $page.ast = [...$page.ast]
+      let parts = $selectedAstElementId.split('.');
+      parts[parts.length - 1] = newIndex.toString();
+      $selectedAstElementId = parts.join('.')
+      // Update in the server
       $live.pushEvent("update_page_ast", { id: $page.id, ast: $page.ast })
     }
   }


### PR DESCRIPTION
Before this change, when sibling elements were reordered with drag and drop, the selected element changed after the drop.

The root cause is that the currently selected elements is stored with a "path" (e.g. `1.4.3.0.2`, meaning the "the third, child of the first child of the fourth child o the fifth child of the second element in the page"), and the last number of that path has to be updated to reflect the new position of the dropped element among its siblings.