### PR TITLE
[Bugfix] Allow to drop elements on the root

### DIFF
--- a/assets/svelte/components/PagePreview.svelte
+++ b/assets/svelte/components/PagePreview.svelte
@@ -15,10 +15,9 @@
     $currentComponentCategory = null
     if (!$draggedObject) return
     let draggedObj = $draggedObject
-    if (elementCanBeDroppedInTarget(draggedObj)) {
+    if (target.id !== "fake-browser-content" && elementCanBeDroppedInTarget(draggedObj)) {
       if (
         !(target instanceof HTMLElement) ||
-        target.id === "fake-browser-content" ||
         !$slotTargetElement ||
         $slotTargetElement.attrs.selfClose
       ) {

--- a/assets/svelte/components/PageWrapper.svelte
+++ b/assets/svelte/components/PageWrapper.svelte
@@ -29,7 +29,7 @@
     window.reloadStylesheet = reloadStylesheet
     reloadStylesheet()
   })
-  page.subscribe(async ({ ast }) => {
+  page.subscribe(async () => {
     await tick()
     window.reloadStylesheet && window.reloadStylesheet()
   })

--- a/assets/svelte/components/SelectedElementFloatingMenu/DragMenuOption.svelte
+++ b/assets/svelte/components/SelectedElementFloatingMenu/DragMenuOption.svelte
@@ -51,7 +51,6 @@
 
 <script lang="ts">
   import { tick } from "svelte"
-
   selectedAstElementId.subscribe(() => updateSelectedElementMenu())
 
   let dragHandleElement: HTMLButtonElement

--- a/assets/svelte/components/UiBuilder.svelte
+++ b/assets/svelte/components/UiBuilder.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+  import { onDestroy } from "svelte"
   import ComponentsSidebar from "./ComponentsSidebar.svelte"
   import Backdrop from "./Backdrop.svelte"
   import PagePreview from "./PagePreview.svelte"
   import PropertiesSidebar from "./PropertiesSidebar.svelte"
   import SelectedElementFloatingMenu from "./SelectedElementFloatingMenu.svelte"
-  import { page as pageStore } from "$lib/stores/page"
+  import { page as pageStore, resetStores } from "$lib/stores/page"
   import { live as liveStore } from "$lib/stores/live"
   import { tailwindConfig as tailwindConfigStore } from "$lib/stores/tailwindConfig"
   import { tailwindInput as tailwindInputStore } from "$lib/stores/tailwindInput"
@@ -19,6 +20,10 @@
   $: $tailwindConfigStore = tailwindConfig
   $: $tailwindInputStore = tailwindInput
   $: $liveStore = live
+
+  onDestroy(() => {
+    resetStores();
+  });
 
   function addBasicComponentToTarget(e: CustomEvent) {
     // This method is in PagePreview.

--- a/assets/svelte/stores/page.ts
+++ b/assets/svelte/stores/page.ts
@@ -5,18 +5,19 @@ import type { CoordsDiff } from "$lib/utils/drag-helpers"
 
 export const page: Writable<Page> = writable()
 export const selectedAstElementId: Writable<string | undefined> = writable()
-// export const highlightedAstElementId: Writable<string | undefined> = writable();
 export const highlightedAstElement: Writable<AstElement | undefined> = writable()
 export const slotTargetElement: Writable<AstElement | undefined> = writable()
 
 export const rootAstElement: Readable<AstElement | undefined> = derived([page], ([$page]) => {
   // This is a virtual AstElement intended to simulate the page itself to reorder the components at the first level.
-  return { tag: "root", attrs: {}, content: $page.ast }
+  if ($page) {
+    return { tag: "root", attrs: {}, content: $page.ast }
+  }
 })
 export const selectedAstElement: Readable<AstElement | undefined> = derived(
   [page, selectedAstElementId],
   ([$page, $selectedAstElementId]) => {
-    if ($selectedAstElementId) {
+    if ($page && $selectedAstElementId) {
       if ($selectedAstElementId === "root") return get(rootAstElement)
       return findAstElement($page.ast, $selectedAstElementId)
     }
@@ -26,7 +27,7 @@ export const selectedAstElement: Readable<AstElement | undefined> = derived(
 export const parentOfSelectedAstElement: Readable<AstElement | undefined> = derived(
   [page, selectedAstElementId],
   ([$page, $selectedAstElementId]) => {
-    if ($selectedAstElementId) {
+    if ($page && $selectedAstElementId) {
       if ($selectedAstElementId === "root") return null
       let levels = $selectedAstElementId.split(".")
       if (levels.length === 1) return get(rootAstElement)
@@ -93,4 +94,13 @@ export function _findAstElementId(ast: AstNode[], astNode: AstNode, id: string):
       }
     }
   }
+}
+
+export function resetStores() {
+  page.set(null)
+  selectedAstElementId.set(null)
+  highlightedAstElement.set(null)
+  slotTargetElement.set(null)
+  selectedDomElement.set(null)
+  selectedElementMenu.set(null)
 }


### PR DESCRIPTION
This also fixes a bug when leaving the visual editor and returning to it with one selected element. Now the stores get reset when the UIEditor is destroyed.

Closes #224 