### PR TITLE
[Visual Editor] Fix a race condition between update AST and save change events

### DIFF
--- a/lib/beacon/live_admin/live/page_editor_live/index.ex
+++ b/lib/beacon/live_admin/live/page_editor_live/index.ex
@@ -14,11 +14,11 @@ defmodule Beacon.LiveAdmin.PageEditorLive.Index do
   end
 
   @impl true
-  def handle_params(params, _uri, %{assigns: %{beacon_page: beacon_page}} = socket) when not is_nil(beacon_page) do
+  def handle_params(params, _uri, %{assigns: %{beacon_page: %{site: site, table: table}}} = socket) when not is_nil(table) do
     socket =
       Table.handle_params(socket, params, &Content.count_pages(&1.site, query: params["query"]))
 
-    %{site: site, table: %{per_page: per_page, current_page: page, query: query, sort_by: sort_by}} = beacon_page
+    %{per_page: per_page, current_page: page, query: query, sort_by: sort_by} = table
 
     pages =
       list_pages(site,


### PR DESCRIPTION
Fix a race condition between updating the AST from client/server and saving the changes made on the template.

Since we have 2 distinct events: one to update the AST and another to actually save the changes, on an env with high latency when one makes a change on the visual editor and hit Save Change there could a race condition that would save the old template because it wasn't updated yet.

So we need to use another assign that is guaranteed to be updated before the save event actually happens.

Close #226 