### PR TITLE
Fixes two editor bugs that slipped through

### DIFF
--- a/assets/svelte/components/PageAstNode.svelte
+++ b/assets/svelte/components/PageAstNode.svelte
@@ -27,7 +27,7 @@
     isAstElement(node) &&
     node.content.filter((e) => typeof e === "string").length === 1 &&
     !node.attrs?.selfClose
-  $: isParentOfSelectedNode = isAstElement(node) ? node.content.includes($selectedAstElement) : false
+  $: isParentOfSelectedNode = (isAstElement(node) && node.content) ? node.content.includes($selectedAstElement) : false
 
   let children
   $: {

--- a/assets/svelte/components/SelectedElementFloatingMenu/DragMenuOption.svelte
+++ b/assets/svelte/components/SelectedElementFloatingMenu/DragMenuOption.svelte
@@ -108,7 +108,7 @@
       }),
     }
     element.parentElement.style.display = "none"
-    element.parentElement.parentElement.insertBefore(el, element.parentElement)
+    element.parentElement.parentNode.insertBefore(el, element.parentElement)
   }
 
   let mouseDownEvent: MouseEvent


### PR DESCRIPTION
One of the bug was not accounting that not all nodes you select have a `content` property. `eex` expressions don't.

The other bug that made the entire page go blank was caused because when a page's DOM estructure, sometimes it's not possible to get the "grandfather" element of an element because there isn't one. However in those situations we can get the DOM Fragment at the root of the web-component.