### PR TITLE
Fixes the calculations of the positions when pages have no wrapper

### DIFF
--- a/assets/svelte/components/PageWrapper.svelte
+++ b/assets/svelte/components/PageWrapper.svelte
@@ -45,9 +45,12 @@
 <div bind:this={wrapper} on:click={preventLinkNavigation}>
   {#each $page.layout.ast as layoutAstNode}
     <LayoutAstNode node={layoutAstNode}>
-      {#each $page.ast as astNode, index}
-        <PageAstNode node={astNode} nodeId={String(index)} />
-      {/each}
+      <!-- This seemingly useless wrapper is here just so we are sure that the layout and the page don't share the same parent, which screws the position calculations -->
+      <div class="contents">
+        {#each $page.ast as astNode, index}
+          <PageAstNode node={astNode} nodeId={String(index)} />
+        {/each}
+      </div>
     </LayoutAstNode>
   {/each}
 </div>


### PR DESCRIPTION
When the elements of the layout and the elements of the page share the same wrapper, positioning calculations are broken.

Adds a wrapper with `display: contents` that doesn't have any effect on CSS, but still allows to tell apart which items belong to the page and which ones belong to the surounding layout.


https://github.com/user-attachments/assets/e7d28020-8c45-46ad-a085-5e8ec57074a4

