### PR TITLE
Allow to drag the parent of the selected element

### DIFF
--- a/assets/svelte/components/PageAstNode.svelte
+++ b/assets/svelte/components/PageAstNode.svelte
@@ -11,7 +11,6 @@
   import { updateNodeContent, updateAst } from "$lib/utils/ast-manipulation"
   import { elementCanBeDroppedInTarget } from "$lib/utils/drag-helpers"
   import type { AstNode } from "$lib/types"
-  import { initSelectedElementDragMenuPosition } from "./SelectedElementFloatingMenu/DragMenuOption.svelte"
   export let node: AstNode
   export let nodeId: string
 
@@ -76,7 +75,6 @@
   function handleClick({ currentTarget }: Event) {
     setSelection(nodeId)
     setSelectedDom(currentTarget)
-    initSelectedElementDragMenuPosition(currentTarget)
   }
 
   function handleContentEdited({ target }: Event) {

--- a/assets/svelte/components/PageWrapper.svelte
+++ b/assets/svelte/components/PageWrapper.svelte
@@ -56,12 +56,12 @@
 </div>
 
 <style>
-  :global([data-selected="true"]) {
+  :global([data-selected="true"], [data-selected-parent="true"]) {
     outline-color: #06b6d4;
     outline-width: 1px;
     outline-style: solid;
   }
-  :global([data-selected="true"].contents > *) {
+  :global([data-selected="true"].contents > *, [data-selected-parent="true"].contents > *) {
     outline-color: #06b6d4;
     outline-width: 1px;
     outline-style: solid;

--- a/assets/svelte/components/SelectedElementFloatingMenu.svelte
+++ b/assets/svelte/components/SelectedElementFloatingMenu.svelte
@@ -56,6 +56,6 @@
 
   <DragMenuOption element={$selectedDomElement} />
   {#if $selectedDomElement?.parentElement}
-    <DragMenuOption element={$selectedDomElement.parentElement} isParent={true}/>
+    <DragMenuOption element={$selectedDomElement.parentElement} isParent={true} />
   {/if}
 {/if}

--- a/assets/svelte/components/SelectedElementFloatingMenu.svelte
+++ b/assets/svelte/components/SelectedElementFloatingMenu.svelte
@@ -55,4 +55,7 @@
   </div>
 
   <DragMenuOption element={$selectedDomElement} />
+  {#if $selectedDomElement?.parentElement}
+    <DragMenuOption element={$selectedDomElement.parentElement} isParent={true}/>
+  {/if}
 {/if}

--- a/assets/svelte/components/SelectedElementFloatingMenu/DragMenuOption.svelte
+++ b/assets/svelte/components/SelectedElementFloatingMenu/DragMenuOption.svelte
@@ -19,7 +19,7 @@
     if (position === 'bottom') {
       return rect.x + rect.width / 2 - 5
     } else {
-      return rect.x - 5
+      return rect.x - 25
     }
   }
   function calculateHandleYPosition(rect: LocationInfo, position: 'bottom' | 'left') {
@@ -48,7 +48,6 @@
   $: canBeDragged = element?.parentElement?.children?.length > 1
   $: dragDirection = getDragDirection(element)
   $: {
-    console.log('#######updated element received!!')
     // Update drag menu position when the element store changes
     !!element && initSelectedElementDragMenuPosition(element, isParent)
   }

--- a/assets/svelte/components/SelectedElementFloatingMenu/DragMenuOption.svelte
+++ b/assets/svelte/components/SelectedElementFloatingMenu/DragMenuOption.svelte
@@ -1,6 +1,12 @@
 <script lang="ts" context="module">
   import { writable, type Writable } from "svelte/store"
-  import { page, selectedAstElementId, parentOfSelectedAstElement, parentSelectedAstElementId, grandParentOfSelectedAstElement } from "$lib/stores/page"
+  import {
+    page,
+    selectedAstElementId,
+    parentOfSelectedAstElement,
+    parentSelectedAstElementId,
+    grandParentOfSelectedAstElement,
+  } from "$lib/stores/page"
   import { findHoveredSiblingIndex, getBoundingRect, getDragDirection, type Coords } from "$lib/utils/drag-helpers"
   import { live } from "$lib/stores/live"
 
@@ -15,21 +21,20 @@
 
   export const isDragging: Writable<boolean> = writable(false)
 
-  function calculateHandleXPosition(rect: LocationInfo, position: 'bottom' | 'left') {
-    if (position === 'bottom') {
+  function calculateHandleXPosition(rect: LocationInfo, position: "bottom" | "left") {
+    if (position === "bottom") {
       return rect.x + rect.width / 2 - 5
     } else {
       return rect.x - 25
     }
   }
-  function calculateHandleYPosition(rect: LocationInfo, position: 'bottom' | 'left') {
-    if (position === 'bottom') {
+  function calculateHandleYPosition(rect: LocationInfo, position: "bottom" | "left") {
+    if (position === "bottom") {
       return rect.y + rect.height + 5
     } else {
       return rect.y + rect.height / 2 - 5
     }
   }
-
 </script>
 
 <script lang="ts">
@@ -57,7 +62,7 @@
       .getElementById("ui-builder-app-container")
       .closest(".relative")
       .getBoundingClientRect()
-    const handlePosition = isParent ? 'left' : 'bottom';
+    const handlePosition = isParent ? "left" : "bottom"
     currentHandleCoords = {
       x: calculateHandleXPosition(currentRect, handlePosition) - relativeWrapperRect.x,
       y: calculateHandleYPosition(currentRect, handlePosition) - relativeWrapperRect.y,
@@ -76,7 +81,7 @@
       styles.push(`left: ${currentHandleCoords.x}px`)
     }
     dragHandleStyle = styles.join(";")
-  }  
+  }
 
   function snapshotSelectedElementSiblings() {
     let siblings = Array.from(element.parentElement.children)
@@ -103,7 +108,7 @@
           left,
         }
       }),
-      newSiblingRects: null
+      newSiblingRects: null,
     }
     // If this is expressed as `element.parentElement.style.display = "none"` for some reason svelte
     // thinks it has to invalidate the `element` and recompute all state that observes it.
@@ -133,11 +138,11 @@
       if (isParent) {
         let parts = $selectedAstElementId.split(".")
         parts[parts.length - 2] = newIndex.toString()
-        $selectedAstElementId = parts.join(".")          
+        $selectedAstElementId = parts.join(".")
       } else {
         let parts = $selectedAstElementId.split(".")
         parts[parts.length - 1] = newIndex.toString()
-        $selectedAstElementId = parts.join(".")        
+        $selectedAstElementId = parts.join(".")
       }
       // console.log('$page.ast[0]', $page.ast[0]);
       $page.ast = [...$page.ast]

--- a/assets/svelte/stores/page.ts
+++ b/assets/svelte/stores/page.ts
@@ -6,34 +6,46 @@ export const page: Writable<Page> = writable()
 export const selectedAstElementId: Writable<string | undefined> = writable()
 export const highlightedAstElement: Writable<AstElement | undefined> = writable()
 export const slotTargetElement: Writable<AstElement | undefined> = writable()
-
 export const rootAstElement: Readable<AstElement | undefined> = derived([page], ([$page]) => {
   // This is a virtual AstElement intended to simulate the page itself to reorder the components at the first level.
   if ($page) {
     return { tag: "root", attrs: {}, content: $page.ast }
   }
 })
+
 export const selectedAstElement: Readable<AstElement | undefined> = derived(
   [page, selectedAstElementId],
   ([$page, $selectedAstElementId]) => {
     if ($page && $selectedAstElementId) {
-      if ($selectedAstElementId === "root") return get(rootAstElement)
       return findAstElement($page.ast, $selectedAstElementId)
     }
   },
 )
 
+function getParentId(id: string | null) {
+  if (id === "root") return null
+  let levels = id.split(".")
+  if (levels.length === 1) return "root"
+  levels.pop()
+  return levels.join(".")  
+}
+
+export const parentSelectedAstElementId: Readable<string> = derived([selectedAstElementId], ([$selectedAstElementId]) => {
+  return getParentId($selectedAstElementId);
+})
+
+export const grandParentSelectedAstElementId: Readable<string> = derived([parentSelectedAstElementId], ([$parentSelectedAstElementId]) => {
+  return getParentId($parentSelectedAstElementId);
+})
+
 export const parentOfSelectedAstElement: Readable<AstElement | undefined> = derived(
-  [page, selectedAstElementId],
-  ([$page, $selectedAstElementId]) => {
-    if ($page && $selectedAstElementId) {
-      if ($selectedAstElementId === "root") return null
-      let levels = $selectedAstElementId.split(".")
-      if (levels.length === 1) return get(rootAstElement)
-      levels.pop()
-      return findAstElement($page.ast, levels.join("."))
-    }
-  },
+  [page, parentSelectedAstElementId],
+  ([$page, $parentSelectedAstElementId]) => findAstElement($page.ast, $parentSelectedAstElementId)
+)
+
+export const grandParentOfSelectedAstElement: Readable<AstElement | undefined> = derived(
+  [page, grandParentSelectedAstElementId],
+  ([$page, $grandParentSelectedAstElementId]) => findAstElement($page.ast, $grandParentSelectedAstElementId)
 )
 
 export const selectedDomElement: Writable<Element | null> = writable(null)
@@ -56,6 +68,7 @@ export function isAstElement(maybeNode: AstNode): maybeNode is AstElement {
 }
 
 export function findAstElement(ast: AstNode[], id: string): AstElement {
+  if (id === "root") return get(rootAstElement);
   let indexes = id.split(".").map((s) => parseInt(s, 10))
   let node: AstNode = ast[indexes[0]] as AstElement
   ast = node.content

--- a/assets/svelte/stores/page.ts
+++ b/assets/svelte/stores/page.ts
@@ -27,25 +27,31 @@ function getParentId(id: string | null) {
   let levels = id.split(".")
   if (levels.length === 1) return "root"
   levels.pop()
-  return levels.join(".")  
+  return levels.join(".")
 }
 
-export const parentSelectedAstElementId: Readable<string> = derived([selectedAstElementId], ([$selectedAstElementId]) => {
-  return getParentId($selectedAstElementId);
-})
+export const parentSelectedAstElementId: Readable<string> = derived(
+  [selectedAstElementId],
+  ([$selectedAstElementId]) => {
+    return getParentId($selectedAstElementId)
+  },
+)
 
-export const grandParentSelectedAstElementId: Readable<string> = derived([parentSelectedAstElementId], ([$parentSelectedAstElementId]) => {
-  return getParentId($parentSelectedAstElementId);
-})
+export const grandParentSelectedAstElementId: Readable<string> = derived(
+  [parentSelectedAstElementId],
+  ([$parentSelectedAstElementId]) => {
+    return getParentId($parentSelectedAstElementId)
+  },
+)
 
 export const parentOfSelectedAstElement: Readable<AstElement | undefined> = derived(
   [page, parentSelectedAstElementId],
-  ([$page, $parentSelectedAstElementId]) => findAstElement($page.ast, $parentSelectedAstElementId)
+  ([$page, $parentSelectedAstElementId]) => findAstElement($page.ast, $parentSelectedAstElementId),
 )
 
 export const grandParentOfSelectedAstElement: Readable<AstElement | undefined> = derived(
   [page, grandParentSelectedAstElementId],
-  ([$page, $grandParentSelectedAstElementId]) => findAstElement($page.ast, $grandParentSelectedAstElementId)
+  ([$page, $grandParentSelectedAstElementId]) => findAstElement($page.ast, $grandParentSelectedAstElementId),
 )
 
 export const selectedDomElement: Writable<Element | null> = writable(null)
@@ -68,7 +74,7 @@ export function isAstElement(maybeNode: AstNode): maybeNode is AstElement {
 }
 
 export function findAstElement(ast: AstNode[], id: string): AstElement {
-  if (id === "root") return get(rootAstElement);
+  if (id === "root") return get(rootAstElement)
   let indexes = id.split(".").map((s) => parseInt(s, 10))
   let node: AstNode = ast[indexes[0]] as AstElement
   ast = node.content

--- a/assets/svelte/utils/drag-helpers.ts
+++ b/assets/svelte/utils/drag-helpers.ts
@@ -69,9 +69,9 @@ function detectFlow(rects: DOMRect[]) {
 // I'm not sure if there's any imaginative layout in which is not good enough, but just in case
 // there's a second logic to check if the parent element uses a horizontal flexbox layout.
 export function getDragDirection(element: Element): DragDirection {
-  let parentEl = element.parentElement
+  let parentEl = element?.parentElement
 
-  if (parentEl === null) {
+  if (!parentEl) {
     return "vertical"
   }
 


### PR DESCRIPTION
## Motivation
Quite often, elements have wrappers with no padding. When there's no padding, it's not possible to select the wrapper of an element because the click always lands on the children. 
Until now, it was possible to click the "Go one level up" button to traverse the tree towards the root, but it was incovenient.

Now, when an element is selected to be dragged, the parent element also shows a handle button to drag it. This makes dragging much more convenient, as there's less steps involved in selecting and dragging the element you intended.

## How does it look
https://github.com/user-attachments/assets/cca176e1-d7c0-4e8b-8928-0fa7f258d82a

