### PR TITLE
chore: remove router helper `beacon_live_admin_url/4`

### DIFF
--- a/lib/beacon/live_admin/router.ex
+++ b/lib/beacon/live_admin/router.ex
@@ -305,20 +305,6 @@ defmodule Beacon.LiveAdmin.Router do
   end
 
   @doc """
-  Generates a `url` with the proper admin prefix for a `site`.
-
-  ## Example
-
-      iex> Beacon.LiveAdmin.Router.beacon_live_admin_url(MyAppWeb.Endpoint, @socket, :my_site, "/pages")
-      "https://myapp.com/my_admin/my_site/pages"
-
-  """
-  def beacon_live_admin_url(endpoint, conn_or_socket, site, path, params \\ %{})
-      when is_atom(site) and is_binary(path) do
-    endpoint.url() <> beacon_live_admin_path(conn_or_socket, site, path, params)
-  end
-
-  @doc """
   Generate the path to serve files in `priv/static`.
 
   See the actual configuration in `Beacon.LiveAdmin.Plug`.

--- a/test/beacon/live_admin/live/live_data_editor_live/index_test.exs
+++ b/test/beacon/live_admin/live/live_data_editor_live/index_test.exs
@@ -73,7 +73,7 @@ defmodule Beacon.LiveAdmin.LiveDataEditorLive.IndexTest do
     refute html =~ ld1.path
   end
 
-  test "raises when missing beacon_live_admin_url in the session" do
+  test "raises when missing beacon_live_admin_page_url in the session" do
     assert_raise RuntimeError, fn ->
       conn =
         Phoenix.ConnTest.dispatch(

--- a/test/beacon/live_admin/live/page_editor_live/index_test.exs
+++ b/test/beacon/live_admin/live/page_editor_live/index_test.exs
@@ -28,7 +28,7 @@ defmodule Beacon.LiveAdmin.PageEditorLive.IndexTest do
     assert_redirected(live, "/admin/site_c/pages")
   end
 
-  test "raises when missing beacon_live_admin_url in the session" do
+  test "raises when missing beacon_live_admin_page_url in the session" do
     assert_raise RuntimeError, fn ->
       conn =
         Phoenix.ConnTest.dispatch(


### PR DESCRIPTION
Every path, including assets paths, are relative to the base url plus the admin prefix and tenant (site name).

To resolve the path we fetch the router from conn/socket so we don't need to know about the host app endpoint.

Ref https://github.com/BeaconCMS/beacon_live_admin/issues/272