### PR TITLE
Fix `phoenix-live-view` version format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - otp: "27"
             elixir: "1.17"
             phoenix: "~> 1.7"
-            phoenix-live-view: "1.0"
+            phoenix-live-view: "~> 1.0"
             postgres: '16.4-alpine'
 
     env:
@@ -100,7 +100,7 @@ jobs:
           - otp: "27"
             elixir: "1.17"
             phoenix: "~> 1.7"
-            phoenix-live-view: "1.0"
+            phoenix-live-view: "~> 1.0"
             postgres: '16.4-alpine'
 
     env:
@@ -184,7 +184,7 @@ jobs:
           - otp: "27"
             elixir: "1.17"
             phoenix: "~> 1.7"
-            phoenix-live-view: "1.0"
+            phoenix-live-view: "~> 1.0"
 
     env:
       MIX_ENV: dev


### PR DESCRIPTION
`maj.min` format only allowed with `~>` prefix