### PR TITLE
Fix draft page creation bug

### DIFF
--- a/lib/beacon/live_admin/live/page_editor_live/form_component.ex
+++ b/lib/beacon/live_admin/live/page_editor_live/form_component.ex
@@ -176,7 +176,7 @@ defmodule Beacon.LiveAdmin.PageEditorLive.FormComponent do
        |> assign(page: page, show_modal: nil)
        |> update(:page_status, &if(user_action == "publish", do: :published, else: &1))
        |> put_flash(:info, "Page #{String.trim_trailing(user_action, "e")}ed successfully")
-       |> push_patch(to: beacon_live_admin_path(socket, site, "/pages/#{page.id}"))}
+       |> push_navigate(to: beacon_live_admin_path(socket, site, "/pages/#{page.id}"))}
     else
       {:error, changeset} ->
         changeset = Map.put(changeset, :action, :save)

--- a/test/beacon/live_admin/live/page_editor_live/new_test.exs
+++ b/test/beacon/live_admin/live/page_editor_live/new_test.exs
@@ -16,11 +16,12 @@ defmodule Beacon.LiveAdmin.PageEditorLive.NewTest do
   test "create new page and patch to edit page", %{conn: conn} do
     {:ok, live, _html} = live(conn, "/admin/site_a/pages/new")
 
-    live
-    |> form("#page-form", page: %{path: "/my/page", title: "My Page", format: "heex"})
-    |> render_submit(%{page: %{"template" => "<div>test</div>"}, save: "save"})
+    {:ok, live, _html} =
+      live
+      |> form("#page-form", page: %{path: "/my/page", title: "My Page", format: "heex"})
+      |> render_submit(%{page: %{"template" => "<div>test</div>"}, save: "save"})
+      |> follow_redirect(conn)
 
-    assert_patch(live)
     assert has_element?(live, "#flash", "Page saved successfully")
     assert has_element?(live, "h1", "Edit Page")
     assert has_element?(live, "button", "Save Changes")

--- a/test/beacon/live_admin/live/page_editor_live/new_test.exs
+++ b/test/beacon/live_admin/live/page_editor_live/new_test.exs
@@ -16,15 +16,14 @@ defmodule Beacon.LiveAdmin.PageEditorLive.NewTest do
   test "create new page and patch to edit page", %{conn: conn} do
     {:ok, live, _html} = live(conn, "/admin/site_a/pages/new")
 
-    {:ok, live, _html} =
-      live
-      |> form("#page-form", page: %{path: "/my/page", title: "My Page", format: "heex"})
-      |> render_submit(%{page: %{"template" => "<div>test</div>"}, save: "save"})
-      |> follow_redirect(conn)
+    live
+    |> form("#page-form", page: %{path: "/my/page", title: "My Page", format: "heex"})
+    |> render_submit(%{page: %{"template" => "<div>test</div>"}, save: "save"})
 
-    assert has_element?(live, "#flash", "Page saved successfully")
-    assert has_element?(live, "h1", "Edit Page")
-    assert has_element?(live, "button", "Save Changes")
+    {path, flash} = assert_redirect(live)
+
+    assert path =~ ~r"^/admin/site_a/pages/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    assert flash["info"] == "Page saved successfully"
   end
 
   describe "extra page fields" do


### PR DESCRIPTION
Using `push_patch` bypasses some of the expected setup which is normally done when navigating to the page editor.  Switching to `push_navigate` will still avoid a full page reload but properly mounts the page