### PR TITLE
Minor Fix for Releases

### DIFF
--- a/lib/beacon/live_admin/cluster.ex
+++ b/lib/beacon/live_admin/cluster.ex
@@ -18,7 +18,7 @@ defmodule Beacon.LiveAdmin.Cluster do
   @doc false
   @impl true
   def init(opts) do
-    {:ok, _} = :pg.start_link(@scope)
+    :pg.start_link(@scope)
     :pg.monitor_scope(@scope)
     :ok = :net_kernel.monitor_nodes(true, node_type: :all)
     {:ok, opts}


### PR DESCRIPTION
### **What will it allow you to do that you can't do today?**

beacon_live_admin retains the same functionality, but a potential blocker for releases is removed.

### **Why do you need this feature and how will it benefit other users?**

While building a release of an umbrella application featuring beacon in one of the child apps and beacon_live_admin in another, I was running into a `MatchError` that was preventing the release from being started:

```bash
** (MatchError) no match of right hand side value: {:error, {:already_started, #PID<0.3898.0>}}
            (beacon_live_admin 0.1.0-dev) lib/beacon/live_admin/cluster.ex:21: Beacon.LiveAdmin.Cluster.init/1
```

By making this small edit, I enabled my release to start successfully.

### **Are there any drawbacks to this feature?**

Not that I can tell. All of beacon_live_admin’s tests still run without failures. The umbrella application still runs successfully with `mix phx.server`. And the release is able to start without any issues.