### PR TITLE
Support gettext ~> 1.0 for Phoenix 1.8 compatibility

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule Beacon.LiveAdmin.MixProject do
       # TODO: tailwind v4 needs more testing
       {:tailwind, "~> 0.2"},
       esbuild_dep(),
-      {:gettext, "~> 0.26"},
+      {:gettext, "~> 0.26 or ~> 1.0"},
       {:jason, "~> 1.0"},
       {:igniter, "~> 0.5", optional: true},
       {:turboprop, "~> 0.1"},


### PR DESCRIPTION
Widen the gettext dependency constraint from `~> 0.26` to `~> 0.26 or ~> 1.0`.

Phoenix 1.8 ships with `{:gettext, "~> 1.0"}`, making beacon_live_admin uninstallable in Phoenix 1.8 projects.

No code changes needed — the codebase already uses the gettext 1.0-compatible API everywhere.

Closes #417